### PR TITLE
fix: `plural_forms`, not `plural-forms`

### DIFF
--- a/po2json.js
+++ b/po2json.js
@@ -10,7 +10,7 @@ if (process.argv.length === 3) {
                 "": {
                     domain: po.headers['X-Domain'] || 'messages',
                     lang: po.headers.Language,
-                    'plural-forms': po.headers['Plural-Forms'],
+                    plural_forms: po.headers['Plural-Forms'],
                 },
             };
 


### PR DESCRIPTION
According to the [description](https://messageformat.github.io/Jed/), the correct key name is `plural_forms`, not `plural-forms`.

Another implementation of `po2json` also uses [`plural_forms`](https://github.com/mikeedwards/po2json/blob/master/lib/parse.js#L136).